### PR TITLE
[ADH-5766] Add option to fully delete table base directory

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg;
 
+import static org.apache.iceberg.TableProperties.DROP_BASE_DIR_ENABLED;
+import static org.apache.iceberg.TableProperties.DROP_BASE_DIR_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
@@ -36,6 +38,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
+import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.metrics.LoggingMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -91,6 +94,18 @@ public class CatalogUtil {
    * @param metadata the last valid TableMetadata instance for a dropped table.
    */
   public static void dropTableData(FileIO io, TableMetadata metadata) {
+    if (supportsDirectoryDelete(io, metadata)) {
+      deleteTableDirectory((SupportsPrefixOperations) io, metadata);
+    } else {
+      deleteTableFiles(io, metadata);
+    }
+  }
+
+  public static void deleteTableDirectory(SupportsPrefixOperations io, TableMetadata metadata) {
+    io.deletePrefix(metadata.location());
+  }
+
+  private static void deleteTableFiles(FileIO io, TableMetadata metadata) {
     // Reads and deletes are done using Tasks.foreach(...).suppressFailureWhenFinished to complete
     // as much of the delete work as possible and avoid orphaned data or manifest files.
 
@@ -135,6 +150,35 @@ public class CatalogUtil {
         "partition statistics",
         true);
     deleteFile(io, metadata.metadataFileLocation(), "metadata");
+  }
+
+  /**
+   * Returns whether the table supports base directory removal.
+   *
+   * @param io a FileIO that will be used for deletes
+   * @param metadata the last valid TableMetadata instance for a table.
+   */
+  public static boolean supportsDirectoryDelete(FileIO io, TableMetadata metadata) {
+    if (!metadata.propertyAsBoolean(DROP_BASE_DIR_ENABLED, DROP_BASE_DIR_ENABLED_DEFAULT)) {
+      return false;
+    }
+
+    if (!metadata.propertyAsBoolean(GC_ENABLED, GC_ENABLED_DEFAULT)) {
+      LOG.warn(
+          "Table directory removal is enabled, but GC is disabled,"
+              + " removing only table metadata files");
+      return false;
+    }
+
+    if (!(io instanceof SupportsPrefixOperations)) {
+      LOG.warn(
+          "Table directory removal is enabled, "
+              + "but IO {} doesn't support it, removing only table files",
+          io.getClass());
+      return false;
+    }
+
+    return true;
   }
 
   @SuppressWarnings("DangerousStringInternUsage")

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -375,4 +375,7 @@ public class TableProperties {
   public static final int ENCRYPTION_DEK_LENGTH_DEFAULT = 16;
 
   public static final int ENCRYPTION_AAD_LENGTH_DEFAULT = 16;
+
+  public static final String DROP_BASE_DIR_ENABLED = "drop.base-directory.enabled";
+  public static final boolean DROP_BASE_DIR_ENABLED_DEFAULT = false;
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -51,6 +52,8 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
@@ -362,8 +365,8 @@ public class SparkCatalog extends BaseCatalog
       ValidationException.check(
           PropertyUtil.propertyAsBoolean(table.properties(), GC_ENABLED, GC_ENABLED_DEFAULT),
           "Cannot purge table: GC is disabled (deleting files may corrupt other tables)");
-      String metadataFileLocation =
-          ((HasTableOperations) table).operations().current().metadataFileLocation();
+      TableMetadata tableMetadata = ((HasTableOperations) table).operations().current();
+      String metadataFileLocation = tableMetadata.metadataFileLocation();
 
       boolean dropped = dropTableWithoutPurging(ident);
 
@@ -373,7 +376,7 @@ public class SparkCatalog extends BaseCatalog
         boolean metadataFileExists = table.io().newInputFile(metadataFileLocation).exists();
 
         if (metadataFileExists) {
-          SparkActions.get().deleteReachableFiles(metadataFileLocation).io(table.io()).execute();
+          deleteTableFiles(table.io(), tableMetadata);
         }
       }
 
@@ -381,6 +384,15 @@ public class SparkCatalog extends BaseCatalog
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       return false;
     }
+  }
+
+  private void deleteTableFiles(FileIO io, TableMetadata tableMetadata) {
+    if (CatalogUtil.supportsDirectoryDelete(io, tableMetadata)) {
+      CatalogUtil.deleteTableDirectory((SupportsPrefixOperations) io, tableMetadata);
+      return;
+    }
+
+    SparkActions.get().deleteReachableFiles(tableMetadata.metadataFileLocation()).io(io).execute();
   }
 
   private boolean dropTableWithoutPurging(Identifier ident) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestDropTable.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestDropTable.java
@@ -101,6 +101,30 @@ public class TestDropTable extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testPurgeTableWithDeleteDirectoryEnabled() throws IOException {
+    String tableBaseDir = validationCatalog.loadTable(tableIdent).location();
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('drop.base-directory.enabled' = 'true')", tableName);
+
+    testPurgeTable();
+
+    assertThat(checkFilesExist(ImmutableList.of(tableBaseDir), false))
+        .as("Base table directory should be deleted")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testPurgeTableWithDeleteDirectoryEnabledAndGcDisabled() throws IOException {
+    String tableBaseDir = validationCatalog.loadTable(tableIdent).location();
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('drop.base-directory.enabled' = 'true')", tableName);
+
+    testPurgeTableGCDisabled();
+
+    assertThat(checkFilesExist(ImmutableList.of(tableBaseDir), true))
+        .as("Base table directory should not be deleted")
+        .isTrue();
+  }
+
+  @TestTemplate
   public void testPurgeTableGCDisabled() throws IOException {
     sql("ALTER TABLE %s SET TBLPROPERTIES (gc.enabled = false)", tableName);
 


### PR DESCRIPTION
- Added `drop.base-directory.enabled` table option to control the removal of table base directory after a table is dropped.