### PR TITLE
[ADS-2674] Add an ignored source operations option to the Kafka connector

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -75,6 +75,7 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.tables.cdc.ops.insert                     | The comma-separated values of the cdc operation field corresponding to INSERT                                    |
 | iceberg.tables.cdc.ops.update                     | The comma-separated values of the cdc operation field corresponding to UPDATE                                    |
 | iceberg.tables.cdc.ops.delete                     | The comma-separated values of the cdc operation field corresponding to DELETE                                    |
+| iceberg.tables.cdc.ops.ignored                    | The comma-separated values of the cdc operation field that should be ignored by connector                        |
 | iceberg.tables.iceberg.tables.upsert-mode-enabled | Set to true to treat all appends as upserts, false otherwise                                                     |
 | iceberg.tables.auto-create-props.*                | Properties set on new tables during auto-create                                                                  |
 | iceberg.tables.write-props.*                      | Properties passed through to Iceberg writer initialization, these take precedence                                |

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -75,6 +75,8 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String TABLES_CDC_OP_UPDATE_DEFAULT = "u";
   private static final String TABLES_CDC_OPS_DELETE_PROP = "iceberg.tables.cdc.ops.delete";
   private static final String TABLES_CDC_OP_DELETE_DEFAULT = "d";
+  private static final String TABLES_CDC_OPS_IGNORE_PROP = "iceberg.tables.cdc.ops.ignored";
+  private static final String TABLES_CDC_OP_IGNORE_DEFAULT = "t,m";
   private static final String TABLES_UPSERT_MODE_ENABLED_PROP =
       "iceberg.tables.upsert-mode-enabled";
   private static final String TABLES_DEFAULT_COMMIT_BRANCH = "iceberg.tables.default-commit-branch";
@@ -289,6 +291,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         TABLES_CDC_OP_DELETE_DEFAULT,
         Importance.MEDIUM,
         "The comma-separated values of the cdc operation field corresponding to DELETE");
+    configDef.define(
+        TABLES_CDC_OPS_IGNORE_PROP,
+        ConfigDef.Type.LIST,
+        TABLES_CDC_OP_IGNORE_DEFAULT,
+        Importance.MEDIUM,
+        "The comma-separated values of the cdc operation field that should be ignored by connector");
   }
 
   private final Map<String, String> originalProps;
@@ -438,6 +446,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public List<String> tablesCdcOpsDelete() {
     return getList(TABLES_CDC_OPS_DELETE_PROP);
+  }
+
+  public List<String> tablesCdcIgnoredOps() {
+    return getList(TABLES_CDC_OPS_IGNORE_PROP);
   }
 
   @VisibleForTesting

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriter.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.IcebergSinkConfig;
@@ -32,6 +34,7 @@ import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -41,18 +44,13 @@ class IcebergWriter implements RecordWriter {
   private final IcebergSinkConfig config;
   private final List<IcebergWriterResult> writerResults;
   private final Map<String, Operation> operationMappings;
+  private final Set<String> ignoredOperations;
 
   private RecordConverter recordConverter;
   private TaskWriter<Record> writer;
 
   IcebergWriter(Table table, String tableName, IcebergSinkConfig config) {
-    this.table = table;
-    this.tableName = tableName;
-    this.config = config;
-    this.writerResults = Lists.newArrayList();
-    this.operationMappings = Maps.newHashMap();
-    initNewWriter();
-    initOperationMappings();
+    this(table, RecordUtils.createTableWriter(table, tableName, config), tableName, config);
   }
 
   IcebergWriter(
@@ -62,6 +60,7 @@ class IcebergWriter implements RecordWriter {
     this.config = config;
     this.writerResults = Lists.newArrayList();
     this.operationMappings = Maps.newHashMap();
+    this.ignoredOperations = Sets.newHashSet();
     this.writer = writer;
     this.recordConverter = new RecordConverter(table, config);
     initOperationMappings();
@@ -75,11 +74,25 @@ class IcebergWriter implements RecordWriter {
   @Override
   public void write(SinkRecord record) {
     try {
-      // ignore tombstones...
-      if (record.value() != null) {
-        Record row = maybeEnrichWithOperation(record, convertToRow(record));
-        writer.write(row);
+      if (record.value() == null) {
+        // ignore tombstones...
+        return;
       }
+
+      Optional<String> rawOperation = extractRawOperation(record);
+      if (rawOperation.filter(ignoredOperations::contains).isPresent()) {
+        // skip ignored operation
+        return;
+      }
+
+      // We enrich a record with an operation only if we have a mapping for it.
+      // Otherwise, we send a raw record to the downstream writer, allowing him to decide
+      // what type of operation to generate, based on the mode (upsert/append).
+      Record row =
+          rawOperation
+              .flatMap(operation -> convertToRowWithOp(record, operation))
+              .orElseGet(() -> convertToRow(record));
+      writer.write(row);
     } catch (Exception e) {
       throw new DataException(
           String.format(
@@ -89,21 +102,17 @@ class IcebergWriter implements RecordWriter {
     }
   }
 
-  private Record maybeEnrichWithOperation(SinkRecord record, Record row) {
-    return Optional.ofNullable(config.tablesCdcField())
-        .map(operationField -> extractOperation(record.value(), operationField))
-        .map(operation -> new RecordWrapper(row, operation))
-        .map(Record.class::cast)
-        .orElse(row);
+  private Optional<Record> convertToRowWithOp(SinkRecord record, String rawOperation) {
+    return Optional.ofNullable(operationMappings.get(rawOperation))
+        .map(operation -> new RecordWrapper(convertToRow(record), operation));
   }
 
-  private Operation extractOperation(Object recordValue, String cdcField) {
-    return Optional.ofNullable(RecordUtils.extractFromRecordValue(recordValue, cdcField))
+  private Optional<String> extractRawOperation(SinkRecord record) {
+    return Optional.ofNullable(config.tablesCdcField())
+        .map(operationField -> RecordUtils.extractFromRecordValue(record.value(), operationField))
         .map(Object::toString)
         .map(String::trim)
-        .map(String::toLowerCase)
-        .map(operationMappings::get)
-        .orElse(Operation.INSERT);
+        .map(String::toLowerCase);
   }
 
   private Record convertToRow(SinkRecord record) {
@@ -167,15 +176,19 @@ class IcebergWriter implements RecordWriter {
     insertOperationMappings(config.tablesCdcOpsInsert(), Operation.INSERT);
     insertOperationMappings(config.tablesCdcOpsUpdate(), Operation.UPDATE);
     insertOperationMappings(config.tablesCdcOpsDelete(), Operation.DELETE);
+
+    normalize(config.tablesCdcIgnoredOps()).forEach(ignoredOperations::add);
   }
 
   private void insertOperationMappings(List<String> cdcOperations, Operation operation) {
-    if (cdcOperations == null || cdcOperations.isEmpty()) {
-      return;
+    normalize(cdcOperations).forEach(cdcOp -> operationMappings.put(cdcOp, operation));
+  }
+
+  private Stream<String> normalize(List<String> operations) {
+    if (operations == null || operations.isEmpty()) {
+      return Stream.empty();
     }
 
-    cdcOperations.stream()
-        .map(String::toLowerCase)
-        .forEach(cdcOp -> operationMappings.put(cdcOp, operation));
+    return operations.stream().map(String::toLowerCase);
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/IcebergWriterTest.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/IcebergWriterTest.java
@@ -26,6 +26,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.Schema;
@@ -81,6 +83,7 @@ public class IcebergWriterTest {
     when(config.tablesCdcOpsInsert()).thenReturn(ImmutableList.of("c", "r"));
     when(config.tablesCdcOpsUpdate()).thenReturn(Collections.singletonList("u"));
     when(config.tablesCdcOpsDelete()).thenReturn(ImmutableList.of("d", "rm"));
+    when(config.tablesCdcIgnoredOps()).thenReturn(ImmutableList.of("m", "t"));
 
     IcebergWriter icebergWriter = new IcebergWriter(table, mockTaskWriter, "ignored", config);
 
@@ -88,8 +91,12 @@ public class IcebergWriterTest {
             record(1, "one", "c", ""),
             record(2, "two", "r", ""),
             record(2, "three", "u", "c"),
+            record(143, "three", "m", "message"),
             record(3, "four", "c", "u"),
+            record(111, "13", "t", "truncate"),
+            record(32, "311", "m", "message"),
             record(1, "one", "d", ""),
+            record(77, "unknown_op", "unknown", "unknown_op"),
             record(2, "two", "rm", ""))
         .forEach(icebergWriter::write);
 
@@ -99,6 +106,7 @@ public class IcebergWriterTest {
         idAndOp(2, Operation.UPDATE),
         idAndOp(3, Operation.INSERT),
         idAndOp(1, Operation.DELETE),
+        idAndOp(77, null),
         idAndOp(2, Operation.DELETE));
   }
 
@@ -109,6 +117,7 @@ public class IcebergWriterTest {
     when(config.tablesCdcOpsInsert()).thenReturn(ImmutableList.of("INSERT", "READ"));
     when(config.tablesCdcOpsUpdate()).thenReturn(Collections.singletonList("UPDATE"));
     when(config.tablesCdcOpsDelete()).thenReturn(ImmutableList.of("DELETE", "REMOVE"));
+    when(config.tablesCdcIgnoredOps()).thenReturn(ImmutableList.of("MESSAGE", "truncate"));
 
     IcebergWriter icebergWriter = new IcebergWriter(table, mockTaskWriter, "ignored", config);
 
@@ -116,8 +125,12 @@ public class IcebergWriterTest {
             record(1, "one", "c", "insert"),
             record(2, "two", "c", "insert"),
             record(2, "three", "c", "update"),
+            record(143, "three", "c", "message"),
             record(3, "four", "r", "read"),
+            record(111, "13", "t", "truncate"),
+            record(32, "311", "f", "truncate"),
             record(1, "one", "c", "delete"),
+            record(77, "unknown_op", "w", "unknown_op"),
             record(2, "two", "r", "remove"))
         .forEach(icebergWriter::write);
 
@@ -127,6 +140,7 @@ public class IcebergWriterTest {
         idAndOp(2, Operation.UPDATE),
         idAndOp(3, Operation.INSERT),
         idAndOp(1, Operation.DELETE),
+        idAndOp(77, null),
         idAndOp(2, Operation.DELETE));
   }
 
@@ -146,8 +160,7 @@ public class IcebergWriterTest {
             record(3, "three", "r", "delete"))
         .forEach(icebergWriter::write);
 
-    assertResults(
-        idAndOp(1, Operation.INSERT), idAndOp(2, Operation.INSERT), idAndOp(3, Operation.INSERT));
+    assertResults(idAndOp(1, null), idAndOp(2, null), idAndOp(3, null));
   }
 
   private void assertResults(Record... expectedRecords) {
@@ -156,17 +169,24 @@ public class IcebergWriterTest {
   }
 
   private List<Record> actualIdAndOps() {
-    return mockTaskWriter.records.stream()
-        .filter(RecordWrapper.class::isInstance)
-        .map(RecordWrapper.class::cast)
-        .map(record -> idAndOp((long) record.getField("id"), record.op()))
-        .collect(Collectors.toList());
+    return mockTaskWriter.records.stream().map(this::toIdAndOp).collect(Collectors.toList());
+  }
+
+  private Record toIdAndOp(Record record) {
+    Operation operation =
+        Optional.of(record)
+            .filter(RecordWrapper.class::isInstance)
+            .map(RecordWrapper.class::cast)
+            .map(RecordWrapper::op)
+            .orElse(null);
+
+    return idAndOp((long) record.getField("id"), operation);
   }
 
   private Record idAndOp(long id, Operation op) {
     GenericRecord genericRecord = GenericRecord.create(ID_AND_OP_SCHEMA);
     genericRecord.setField("id", id);
-    genericRecord.setField("operation", op.toString());
+    genericRecord.setField("operation", Objects.toString(op, null));
     return genericRecord;
   }
 


### PR DESCRIPTION
Added `iceberg.tables.cdc.ops.ignored` option to ignore the records from Kafka with specified values of the CDC operation field