### PR TITLE
ADH-8531 # correctly skip non iceberg SparkTable

### DIFF
--- a/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteOperationForRowLineage.scala
+++ b/spark/v3.4/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteOperationForRowLineage.scala
@@ -42,6 +42,7 @@ trait RewriteOperationForRowLineage extends RewriteRowLevelIcebergCommand {
         r.table match {
           case sparkTable: SparkTable =>
             TableUtil.supportsRowLineage(sparkTable.table())
+          case _ => false
         }
       case _ => false
     }

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteOperationForRowLineage.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteOperationForRowLineage.scala
@@ -42,6 +42,7 @@ trait RewriteOperationForRowLineage extends RewriteRowLevelCommand {
         r.table match {
           case sparkTable: SparkTable =>
             TableUtil.supportsRowLineage(sparkTable.table())
+          case _ => false
         }
       case _ => false
     }


### PR DESCRIPTION
This patch is required to make it possible to simultaneously run iceberg & paimon table formats using spark 3.4/3.5